### PR TITLE
Add additional checks for Accounts[1] to the validator app.

### DIFF
--- a/contracts/validator_approval.teal
+++ b/contracts/validator_approval.teal
@@ -312,6 +312,16 @@ redeem_fees:
 
 // Redeem
 redeem:
+    // ensure Accounts[1] is the Pooler/Swapper (receiver of txn 2)
+    gtxn 2 AssetReceiver
+    gtxn 2 Receiver
+    gtxn 2 TypeEnum
+    int pay
+    == // if algo
+    select
+    txna Accounts 1
+    ==
+    assert
     // ensure redeeming amount > 0
     load 52 // gtxn_2_amount
     assert
@@ -531,6 +541,12 @@ mint_burn__1:
 // excess_asset2_amount += excess_asset_2
 
 // burn
+    // ensure Accounts[1] is the Pooler (sender of txn 4)
+    txna Accounts 1
+    gtxn 4 Sender
+    ==
+    assert
+
     gtxn 4 AssetAmount // burn_amount
     load 71 // asset1_supply
     mulw // burn_amount * asset1_supply
@@ -622,6 +638,12 @@ mint_burn__1:
 // put excess_liquidity_token_amount += excess_liquidity_token
 
 mint:
+    // ensure Accounts[1] is the Pooler (sender of txn 2)
+    txna Accounts 1
+    gtxn 2 Sender
+    ==
+    assert
+
     load 71 // asset1_supply
     load 52 // gtxn_2_amount
     +
@@ -833,6 +855,12 @@ mint:
 
 
 swap:
+    // ensure Accounts[1] is the Swapper (sender of txn 2)
+    txna Accounts 1
+    gtxn 2 Sender
+    ==
+    assert
+
     // Is asset_in == asset1 and asset_out == asset2? 
     gtxn 2 XferAsset
     load 101 // asset1_id


### PR DESCRIPTION
This PR fixes an issue that was reported to the Bug Bounty Program for the V1.1 contracts. The issue applies to both the V1.0 and current version of the V1.1 contracts.


The Validator App must write to local state of Poolers and Swappers to store excess amounts. The Validator App assumes that Accounts[1] (`txna Accounts 1`) is the address of the Pooler or Swapper carrying out the operation.
The LogicSig contains checks to ensure that this is the case. e.g https://github.com/tinymanorg/tinyman-contracts-v1/blob/main/contracts/pool_logicsig.teal.tmpl#L355:L364

These checks ensure that the correct account is updated with excess when doing a mint/burn/swap/redeem with a genuine pool. However they do not stop a malicious actor from crafting an operation with a 'fake' pool does not include this check. This allows the malicious actor to write excess amounts to any other users account, even if they are not participating in the transaction.

This is a problem because it allows an account to fill all 16 slots of local state with unnecessary excess entries and thus prevent the user from doing further swap/mint/burns until they clear state. This could be annoying for users and could cause problems for bot accounts.

This issue does NOT allow a malicious actor to modify any state set by genuine pools as these state keys are namespaced by the pool address.

As can be seen from the changes, this PR only adds additional assertions. No existing logic is removed or modified.
The appropriate checks to ensure Accounts[1] is the Swapper/Pooler are added to the Validator App for each operation.
Existing checks in pool_logicsig.teal.tmpl are now redundant but are kept to reduce code changes. They cause no harm.